### PR TITLE
Adds support for language tags in labels and defn.

### DIFF
--- a/skos.py
+++ b/skos.py
@@ -655,7 +655,7 @@ class RDFLoader(collections.Mapping):
     Use the `RDFBuilder` class to convert the Python SKOS objects back
     into a RDF graph.
     """
-    def __init__(self, graph, max_depth=0, flat=False, normalise_uri=str):
+    def __init__(self, graph, max_depth=0, flat=False, normalise_uri=str, lang=None):
         if not isinstance(graph, rdflib.Graph):
             raise TypeError('`rdflib.Graph` type expected for `graph` argument, found: %s' % type(graph))
 
@@ -670,7 +670,7 @@ class RDFLoader(collections.Mapping):
             raise TypeError('callable expected for `normalise_uri` argument')
         self.normalise_uri = normalise_uri
 
-        self.load(graph)       # convert the graph to our object model
+        self.load(graph, lang)       # convert the graph to our object model
 
     def _dcDateToDatetime(self, date):
         """
@@ -738,7 +738,18 @@ class RDFLoader(collections.Mapping):
         for subject in graph.subjects(predicate=predicate, object=object_):
             yield subject
 
-    def _loadConcepts(self, graph, cache):
+    def _get_value_for_lang(self, graph, subject, predicate, lang):
+        objects = graph.objects(subject=subject, predicate=predicate)
+        if not objects:
+            return None
+
+        for obj in objects:
+            if obj.language == lang:
+                return obj.value
+
+        return None
+
+    def _loadConcepts(self, graph, cache, lang):
         # generate all the concepts
         concepts = set()
         normalise_uri = self.normalise_uri
@@ -746,13 +757,19 @@ class RDFLoader(collections.Mapping):
         definition = rdflib.URIRef('http://www.w3.org/2004/02/skos/core#definition')
         notation = rdflib.URIRef('http://www.w3.org/2004/02/skos/core#notation')
         altLabel = rdflib.URIRef('http://www.w3.org/2004/02/skos/core#altLabel')
+
         for subject in self._iterateType(graph, 'Concept'):
             uri = normalise_uri(subject)
-            # create the basic concept
-            label = unicode(graph.value(subject=subject, predicate=prefLabel))
-            defn = unicode(graph.value(subject=subject, predicate=definition))
+
+            # Check for a preferredLabel in our desired language
+            label_list = graph.preferredLabel(subject, lang=lang)
+            label = unicode(label_list[0][1].value)
+
+            defn = self._get_value_for_lang(graph, subject, definition, lang)
+            alt = self._get_value_for_lang(graph, subject, altLabel, lang)
+
             notn = unicode(graph.value(subject=subject, predicate=notation))
-            alt = unicode(graph.value(subject=subject, predicate=altLabel))
+
             debug('creating Concept %s', uri)
             cache[uri] = Concept(uri, label, defn, notn, alt)
             concepts.add(uri)
@@ -828,14 +845,14 @@ class RDFLoader(collections.Mapping):
 
         return schemes
 
-    def load(self, graph):
+    def load(self, graph, lang='en'):
         cache = {}
         normalise_uri = self.normalise_uri
         self._concepts = set((normalise_uri(subj) for subj in self._iterateType(graph, 'Concept')))
         self._collections = set((normalise_uri(subj) for subj in self._iterateType(graph, 'Collection')))
         self._schemes = set((normalise_uri(subj) for subj in self._iterateType(graph, 'ConceptScheme')))
         self._resolveGraph(graph)
-        self._flat_concepts = self._loadConcepts(graph, cache)
+        self._flat_concepts = self._loadConcepts(graph, cache, lang)
         self._flat_collections = self._loadCollections(graph, cache)
         self._flat_schemes = self._loadConceptSchemes(graph, cache)
         self._flat_cache = cache # all objects

--- a/skos.py
+++ b/skos.py
@@ -698,13 +698,14 @@ class RDFLoader(collections.Mapping):
             rdflib.URIRef('http://www.w3.org/2004/02/skos/core#exactMatch'),
             rdflib.URIRef('http://www.w3.org/2006/12/owl2-xml#sameAs'),
             rdflib.URIRef('http://www.w3.org/2004/02/skos/core#related'),
-            rdflib.URIRef('http://www.w3.org/2004/02/skos/core#member')
+            rdflib.URIRef('http://www.w3.org/2004/02/skos/core#member'),
             )
 
         resolvable_objects = (
             rdflib.URIRef('http://www.w3.org/2004/02/skos/core#ConceptScheme'),
             rdflib.URIRef('http://www.w3.org/2004/02/skos/core#Concept'),
-            rdflib.URIRef('http://www.w3.org/2004/02/skos/core#Collection')
+            rdflib.URIRef('http://www.w3.org/2004/02/skos/core#Collection'),
+            rdflib.URIRef('http://www.w3.org/2004/02/skos/core#hasTopConcept'),
             )
 
         normalise_uri = self.normalise_uri
@@ -744,7 +745,7 @@ class RDFLoader(collections.Mapping):
             return None
 
         for obj in objects:
-            if obj.language == lang:
+            if hasattr(obj, "language") and obj.language == lang:
                 return obj.value
 
         return None

--- a/test/concepts-unicode-languages.xml
+++ b/test/concepts-unicode-languages.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dc="http://purl.org/dc/terms/" xmlns:owlxml="http://www.w3.org/2006/12/owl2-xml#">
+  <skos:Collection rdf:about="http://portal.oceannet.org/collection/unicode">
+    <dc:title>Test Unicode Collection ó</dc:title>
+    <dc:description>A collection of concepts used as a test ó</dc:description>
+    <dc:date>2012-04-26T08:43:53.808+0000</dc:date>
+    <skos:member>
+      <skos:Concept rdf:about="http://portal.oceannet.org/test1/unicode">
+        <skos:notation>test1-unicode-ó</skos:notation>
+        <skos:prefLabel xml:lang="fr">Notion de test Unicode: ó</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">Unicode test concept: ó</skos:prefLabel>
+        <skos:prefLabel xml:lang="es">Concepto de prueba Unicode: ó</skos:prefLabel>
+        <skos:definition xml:lang="fr">Test caractère unicode ó</skos:definition>
+        <skos:definition xml:lang="en">Testing unicode character ó</skos:definition>
+        <skos:definition xml:lang="es">Prueba de caracteres unicode ó</skos:definition>
+        <skos:altLabel xml:lang="fr">Test de remplacement: ó</skos:altLabel>
+        <skos:altLabel xml:lang="en">Alternative test: ó</skos:altLabel>
+        <skos:altLabel xml:lang="es">Prueba alternativa: ó</skos:altLabel>
+        <skos:related rdf:resource="http://portal.oceannet.org/test/dc"/>
+        <owlxml:sameAs rdf:resource="http://portal.oceannet.org/test2/dc"/>
+      </skos:Concept>
+    </skos:member>
+  </skos:Collection>
+</rdf:RDF>

--- a/test/test_rdfloader.py
+++ b/test/test_rdfloader.py
@@ -23,7 +23,7 @@ class TestRDFLoaderConstructor(unittest.TestCase):
             skos.RDFLoader(graph, normalise_uri='oops')
 
 class TestCase(unittest.TestCase):
-    
+
     def __init__(self, rdf_files, *args, **kwargs):
         super(TestCase, self).__init__(*args, **kwargs)
         self.rdf_files = rdf_files
@@ -43,12 +43,24 @@ class TestUnicode(TestCase):
     def __init__(self, *args, **kwargs):
         rdf_files = [
             'concepts-unicode.xml',
-            'schemes-unicode.xml'
+            'schemes-unicode.xml',
+            'concepts-unicode-languages.xml'
         ]
         super(TestUnicode, self).__init__(rdf_files, *args, **kwargs)
 
+    def getLoader(self, graph):
+        return skos.RDFLoader(graph, 0, lang='es')
+
     def testLen(self):
         self.assertEqual(len(self.loader), 3)
+
+    def testLanguages(self):
+        concept = self.loader.getConcepts()['http://portal.oceannet.org/test1/unicode']
+
+        assert concept.prefLabel == u'Concepto de prueba Unicode: ó', concept.prefLabel
+        assert concept.altLabel == u'Prueba alternativa: ó', concept.altLabel
+        assert concept.definition == u'Prueba de caracteres unicode ó', concept.definition
+
 
 class TestRDFLoader(TestCase):
     """
@@ -146,7 +158,7 @@ class TestRDFParsing(TestRDFLoader):
 
     def getExternalResource(self, resource):
         return 'file://' + os.path.join(os.path.dirname(os.path.abspath(__file__)), resource)
-    
+
     def testSynonyms(self):
         concept = self.loader['http://portal.oceannet.org/test']
         key = self.getExternalResource('external1-dce.xml')


### PR DESCRIPTION
Currently python-skos ignores the xml:lang attribute if it is present on a preferredLabel and altLabel, returning whichever happens to get parsed/found first.

This change allows you to specify a language in the loader which is then used when loading concepts to pull that specific language version. It currently defaults to en if the language is not specified.

This PR should close #3