### PR TITLE
added a default object to return if a label was not found.

### DIFF
--- a/skos.py
+++ b/skos.py
@@ -759,11 +759,14 @@ class RDFLoader(collections.Mapping):
         notation = rdflib.URIRef('http://www.w3.org/2004/02/skos/core#notation')
         altLabel = rdflib.URIRef('http://www.w3.org/2004/02/skos/core#altLabel')
 
+        default_label = [[None, type('obj', (object,), {'value':""})]]
+
         for subject in self._iterateType(graph, 'Concept'):
             uri = normalise_uri(subject)
 
             # Check for a preferredLabel in our desired language
-            label_list = graph.preferredLabel(subject, lang=lang)
+            label_list = graph.preferredLabel(subject, lang=lang, default=default_label)
+
             label = unicode(label_list[0][1].value)
 
             defn = self._get_value_for_lang(graph, subject, definition, lang)


### PR DESCRIPTION
Added this because I had crashes using a large skos file. When a single xml:lang="xx" entry was missing from a label, the program would crash. Now it just replaces the label with "MISSING TRANSLATION!" instead.
